### PR TITLE
improve: do not pass dirs when instantiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "autod": "*",
     "contributors": "*",
-    "cov": "*",
     "istanbul": "*",
     "jshint": "*",
     "mocha": "*",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -52,8 +52,7 @@ describe('index.test.js', function () {
     var filepath = path.join(fixtures, '.file.txt.swp');
     fs.writeFile(filepath, 'vim tmp file\n', done);
 
-    var lastpath = null;
-    this.watcher.on('file', function (info) {
+    this.watcher.on('file', function () {
       throw new Error('should not run this');
     });
     setTimeout(done, 200);
@@ -64,8 +63,7 @@ describe('index.test.js', function () {
     var dirpath = path.join(fixtures, '.createdir');
     fs.mkdir(dirpath, done);
 
-    var lastpath = null;
-    this.watcher.on('dir', function (info) {
+    this.watcher.on('dir', function () {
       throw new Error('should not run this');
     });
     setTimeout(done, 200);

--- a/test/multi_dirs.test.js
+++ b/test/multi_dirs.test.js
@@ -23,7 +23,7 @@ var wt = require('../');
 describe('multi_dirs.test.js', function () {
   var fixtures = path.join(__dirname, 'fixtures');
 
-  beforeEach(function (done) {
+  beforeEach(function(done) {
     this.watcher = wt.watch([
       path.join(fixtures, 'subdir'),
       path.join(fixtures, 'otherdir')
@@ -34,21 +34,12 @@ describe('multi_dirs.test.js', function () {
     this.watcher.close();
   });
 
-  after(function (done) {
-    var filepath1 = path.join(fixtures, 'subdir', 'subsubdeldir');
-    var filepath2 = path.join(fixtures, 'otherdir', 'subsubdeldir');
-    fs.existsSync(filepath1) && fs.rmdirSync(filepath1);
-    fs.existsSync(filepath2) && fs.rmdirSync(filepath2);
-
-    setTimeout(done, 500);
-  });
-
   it('should watch file change on subdir and otherdir', function (_done) {
     var filepath1 = path.join(fixtures, 'subdir', 'subfoo.txt');
     var filepath2 = path.join(fixtures, 'otherdir', 'otherfoo.txt');
     var changefiles = [];
 
-    var done = pedding(4, function (err) {
+    var done = pedding(2, function (err) {
       should.not.exist(err);
       changefiles.should.length(2);
       should.ok(changefiles.indexOf(filepath1) >= 0);
@@ -56,8 +47,8 @@ describe('multi_dirs.test.js', function () {
       _done();
     });
 
-    fs.writeFile(filepath1, 'bar', done);
-    fs.writeFile(filepath2, 'bar', done);
+    fs.writeFileSync(filepath1, 'bar');
+    fs.writeFileSync(filepath2, 'bar');
 
     this.watcher.on('file', function (info) {
       if (changefiles.indexOf(info.path) >= 0) {
@@ -76,7 +67,7 @@ describe('multi_dirs.test.js', function () {
     var changefiles = [];
     var changealls = [];
 
-    var done = pedding(6, function (err) {
+    var done = pedding(4, function (err) {
       should.not.exist(err);
       changefiles.should.length(2);
       changealls.should.length(2);
@@ -87,8 +78,8 @@ describe('multi_dirs.test.js', function () {
       _done();
     });
 
-    fs.writeFile(filepath1, 'subbar', done);
-    fs.writeFile(filepath2, 'subbar', done);
+    fs.writeFileSync(filepath1, 'subbar');
+    fs.writeFileSync(filepath2, 'subbar');
 
     this.watcher.on('file', function (info) {
       if (changefiles.indexOf(info.path) >= 0) {
@@ -107,89 +98,104 @@ describe('multi_dirs.test.js', function () {
     });
   });
 
-  it('should watch file remove', function (_done) {
+  describe('remove file', function() {
     var filepath1 = path.join(fixtures, 'subdir', 'subsubdel.txt');
     var filepath2 = path.join(fixtures, 'otherdir', 'subsubdel.txt');
-    fs.writeFileSync(filepath1, 'need to be delete');
-    fs.writeFileSync(filepath2, 'need to be delete123');
 
-    var removefiles = [];
-    var allfiles = [];
-    var done = pedding(6, function (err) {
-      should.not.exist(err);
-      removefiles.should.length(2);
-      allfiles.should.length(2);
-      should.ok(removefiles.indexOf(filepath1) >= 0);
-      should.ok(removefiles.indexOf(filepath2) >= 0);
-      should.ok(allfiles.indexOf(filepath1) >= 0);
-      should.ok(allfiles.indexOf(filepath2) >= 0);
-      _done();
+    before(function(done) {
+      done = pedding(2, done);
+      fs.writeFile(filepath1, 'need to be delete', done);
+      fs.writeFile(filepath2, 'need to be delete123', done);
     });
 
-    fs.unlink(filepath1, done);
-    fs.unlink(filepath2, done);
+    it('should watch file remove', function (_done) {
+      var removefiles = [];
+      var allfiles = [];
 
-    this.watcher.on('remove', function (info) {
-      if (info.path.indexOf('/sub/ubdel.txt') > 0) {
-        // this a bug on node@0.11.x fs.watch
-        return;
-      }
-      if (removefiles.indexOf(info.path) >= 0) {
-        // repeat emit
-        return;
-      }
-      removefiles.push(info.path);
-      info.event.should.equal('rename');
-      info.isFile.should.equal(false);
-      info.remove.should.equal(true);
-      done();
-    }).on('all', function (info) {
-      if (info.path.indexOf('/sub/ubdel.txt') > 0) {
-        // this a bug on node@0.11.x fs.watch
-        return;
-      }
-      if (allfiles.indexOf(info.path) >= 0) {
-        // repeat emit
-        return;
-      }
-      allfiles.push(info.path);
-      info.event.should.equal('rename');
-      info.isFile.should.equal(false);
-      info.remove.should.equal(true);
-      done();
-    });
-  });
-
-  it('should watch dir remove', function (_done) {
-    var filepath1 = path.join(fixtures, 'subdir', 'subsubdeldir');
-    var filepath2 = path.join(fixtures, 'otherdir', 'subsubdeldir');
-    fs.existsSync(filepath1) && fs.rmdirSync(filepath1);
-    fs.existsSync(filepath2) && fs.rmdirSync(filepath2);
-
-    fs.mkdirSync(filepath1);
-    fs.mkdirSync(filepath2);
-
-    var watcher = this.watcher;
-
-    function run() {
-      var removedirs = [];
-      var alldirs = [];
-
-      var done = pedding(6, function (err) {
+      var done = pedding(4, function (err) {
         should.not.exist(err);
-        alldirs.should.length(2);
-        removedirs.should.length(2);
-        should.ok(alldirs.indexOf(filepath1) >= 0);
-        should.ok(alldirs.indexOf(filepath2) >= 0);
-        should.ok(removedirs.indexOf(filepath1) >= 0);
-        should.ok(removedirs.indexOf(filepath2) >= 0);
+        removefiles.should.length(2);
+        allfiles.should.length(2);
+        should.ok(removefiles.indexOf(filepath1) >= 0);
+        should.ok(removefiles.indexOf(filepath2) >= 0);
+        should.ok(allfiles.indexOf(filepath1) >= 0);
+        should.ok(allfiles.indexOf(filepath2) >= 0);
         _done();
       });
 
-      fs.rmdir(filepath1, done);
-      fs.rmdir(filepath2, done);
+      fs.unlinkSync(filepath1, done);
+      fs.unlinkSync(filepath2, done);
 
-      watcher.on('remove', function (info) {
+      this.watcher.on('remove', function (info) {
+        if (info.path.indexOf('/sub/ubdel.txt') > 0) {
+          // this a bug on node@0.11.x fs.watch
+          return;
+        }
+        if (removefiles.indexOf(info.path) >= 0) {
+          // repeat emit
+          return;
+        }
+        removefiles.push(info.path);
+        info.event.should.equal('rename');
+        info.isFile.should.equal(false);
+        info.remove.should.equal(true);
+        done();
+      }).on('all', function (info) {
+        if (info.path.indexOf('/sub/ubdel.txt') > 0) {
+          // this a bug on node@0.11.x fs.watch
+          return;
+        }
+        if (allfiles.indexOf(info.path) >= 0) {
+          // repeat emit
+          return;
+        }
+        allfiles.push(info.path);
+        info.event.should.equal('rename');
+        info.isFile.should.equal(false);
+        info.remove.should.equal(true);
+        done();
+      });
+    });
+  });
+
+  describe('remove dir', function() {
+    var dirpath1 = path.join(fixtures, 'subdir', 'subsubdeldir');
+    var dirpath2 = path.join(fixtures, 'otherdir', 'subsubdeldir');
+
+    before(function(done) {
+      done = pedding(2, done);
+      fs.existsSync(dirpath1) && fs.rmdirSync(dirpath1);
+      fs.existsSync(dirpath2) && fs.rmdirSync(dirpath2);
+      fs.mkdir(dirpath1, done);
+      fs.mkdir(dirpath2, done);
+    });
+
+    after(function (done) {
+      fs.existsSync(dirpath1) && fs.rmdirSync(dirpath1);
+      fs.existsSync(dirpath2) && fs.rmdirSync(dirpath2);
+      setTimeout(done, 500);
+    });
+
+
+    it('should watch dir remove', function (_done) {
+      var removedirs = [];
+      var alldirs = [];
+
+      var done = pedding(4, function (err) {
+        should.not.exist(err);
+        alldirs.should.length(2);
+        removedirs.should.length(2);
+        should.ok(alldirs.indexOf(dirpath1) >= 0);
+        should.ok(alldirs.indexOf(dirpath2) >= 0);
+        should.ok(removedirs.indexOf(dirpath1) >= 0);
+        should.ok(removedirs.indexOf(dirpath2) >= 0);
+        _done();
+      });
+
+      fs.rmdirSync(dirpath1);
+      fs.rmdirSync(dirpath2);
+
+      this.watcher.on('remove', function (info) {
         if (info.path.indexOf('/sub/ubdeldir') > 0) {
           // this a bug on node@0.11.x fs.watch
           return;
@@ -220,69 +226,61 @@ describe('multi_dirs.test.js', function () {
         info.isDirectory.should.equal(true);
         done();
       });
-    }
-
-    var count = 0;
-    watcher.once('watch-' + filepath2, function () {
-      if (++count === 2) {
-        run();
-      }
-    });
-    watcher.once('watch-' + filepath1, function () {
-      if (++count === 2) {
-        run();
-      }
     });
   });
 
-  it('should watch dir create', function (_done) {
+  describe('create', function() {
+
     var filepath1 = path.join(fixtures, 'subdir', 'subsubdeldir');
     var filepath2 = path.join(fixtures, 'otherdir', 'subsubdeldir');
-    fs.existsSync(filepath1) && fs.rmdirSync(filepath1);
-    fs.existsSync(filepath2) && fs.rmdirSync(filepath2);
 
-    var changedirs = [];
-    var alldirs = [];
-
-    var done = pedding(6, function (err) {
-      should.not.exist(err);
-      changedirs.should.length(2);
-      alldirs.should.length(2);
-      _done();
+    before(function() {
+      fs.existsSync(filepath1) && fs.rmdirSync(filepath1);
+      fs.existsSync(filepath2) && fs.rmdirSync(filepath2);
     });
 
-    fs.mkdir(filepath1, done);
-    fs.mkdir(filepath2, done);
+    it('should watch dir create', function (_done) {
+      var changedirs = [];
+      var alldirs = [];
 
-    var indexfile = 0;
-    var indexall = 0;
-    this.watcher.on('dir', function (info) {
-      if (info.path.indexOf('/sub/ubdeldir') > 0) {
-        info.remove.should.equal(true);
-        // this a bug on node@0.11.x fs.watch
-        return;
-      }
-      if (changedirs.indexOf(info.path) >= 0) {
-        return;
-      }
-      changedirs.push(info.path);
-      info.isFile.should.equal(false);
-      info.isDirectory.should.equal(true);
-      info.remove.should.equal(false);
-      done();
-    }).on('all', function (info) {
-      if (info.path.indexOf('/sub/ubdeldir') > 0) {
-        // this a bug on node@0.11.x fs.watch
-        return;
-      }
-      if (alldirs.indexOf(info.path) >= 0) {
-        return;
-      }
-      alldirs.push(info.path);
-      info.isFile.should.equal(false);
-      info.isDirectory.should.equal(true);
-      info.remove.should.equal(false);
-      done();
+      var done = pedding(4, function (err) {
+        should.not.exist(err);
+        changedirs.should.length(2);
+        alldirs.should.length(2);
+        _done();
+      });
+
+      fs.mkdirSync(filepath1);
+      fs.mkdirSync(filepath2);
+
+      this.watcher.on('dir', function (info) {
+        if (info.path.indexOf('/sub/ubdeldir') > 0) {
+          info.remove.should.equal(true);
+          // this a bug on node@0.11.x fs.watch
+          return;
+        }
+        if (changedirs.indexOf(info.path) >= 0) {
+          return;
+        }
+        changedirs.push(info.path);
+        info.isFile.should.equal(false);
+        info.isDirectory.should.equal(true);
+        info.remove.should.equal(false);
+        done();
+      }).on('all', function (info) {
+        if (info.path.indexOf('/sub/ubdeldir') > 0) {
+          // this a bug on node@0.11.x fs.watch
+          return;
+        }
+        if (alldirs.indexOf(info.path) >= 0) {
+          return;
+        }
+        alldirs.push(info.path);
+        info.isFile.should.equal(false);
+        info.isDirectory.should.equal(true);
+        info.remove.should.equal(false);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
It's a break change on Class of Watcher, but compatible with wt.watch

```
new Watcher(opt)
.watch(dirs)
.watch(dir)
.on('error', callback)
.on('watch', callback)
.on('all', listener)
.on('file', listener)
.on('remove', listener)
.on('dir', listener)
```